### PR TITLE
Fix incorrectly applied buffs when out of Arcanist points

### DIFF
--- a/BubbleBuffs/BubbleBuffs.csproj
+++ b/BubbleBuffs/BubbleBuffs.csproj
@@ -62,27 +62,22 @@
   </Target>
   <Target Name="Publicise" AfterTargets="CreateLib">
     <ItemGroup>
-      <PubliciseAssemblyCSharp Include="$(WrathPathDebug)\Wrath_Data\Managed\Assembly-CSharp.dll;$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.UI.dll" />
-      <PubliciseUniRx Include="$(WrathPathDebug)\Wrath_Data\Managed\UniRx.dll" />
+      <PubliciseAssemblyCSharp Include="C:\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Assembly-CSharp.dll;C:\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Owlcat.Runtime.UI.dll" />
+      <PubliciseUniRx Include="C:\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UniRx.dll" />
     </ItemGroup>
     <Publicise InputAssemblies="@(PubliciseAssemblyCSharp)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true" />
     <Publicise InputAssemblies="@(PubliciseUniRx)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true" />
   </Target>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityModManager\0Harmony.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>$(SolutionDir)lib\Assembly-CSharp_public.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Owlcat.Runtime.UI">
-      <HintPath>$(SolutionDir)lib\Owlcat.Runtime.UI_public.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Assembly-CSharp_public">
+      <HintPath>..\lib\Assembly-CSharp_public.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
@@ -91,13 +86,22 @@
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Owlcat.Runtime.UI_public">
+      <HintPath>..\lib\Owlcat.Runtime.UI_public.dll</HintPath>
+    </Reference>
+    <Reference Include="Owlcat.Runtime.UniRx">
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Owlcat.Runtime.UniRx.dll</HintPath>
+    </Reference>
     <Reference Include="Owlcat.Runtime.Validation">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\Owlcat.Runtime.Validation.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Owlcat.Runtime.Validation.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Owlcat.Runtime.Core">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\Owlcat.Runtime.Core.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Owlcat.Runtime.Core.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Owlcat.Runtime.Visual">
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Owlcat.Runtime.Visual.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -107,16 +111,15 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UniRx">
-      <HintPath>$(SolutionDir)lib\UniRx_public.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UniRx_public">
+      <HintPath>..\lib\UniRx_public.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>D:\steamlib\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.TextMeshPro">
-      <HintPath>D:\steamlib\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -126,19 +129,19 @@
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
@@ -150,19 +153,19 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DOTweenPro">
@@ -174,11 +177,11 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="DOTween">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\DOTween.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\DOTween.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityModManager">
-      <HintPath>$(WrathPathDebug)\Wrath_Data\Managed\UnityModManager\UnityModManager.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\UnityModManager\UnityModManager.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -253,11 +256,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <EmbeddedResource Include="Config\zh_CN.json" />
-  </ItemGroup>
-  <ItemGroup>
+   <ItemGroup>
     <Content Include="Assets\icons\apply_buffs_down.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -292,12 +291,22 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Config\zh_CN.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" AfterTargets="BeforeClean">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props'))" />
+  </Target>
+  <Target Name="Publicize" AfterTargets="Clean">
+    <ItemGroup>
+      <!-- Use $(KingmakerPath)\Kingmaker_Data\Managed\Assembly-CSharp.dll for Kingmaker -->
+      <Assemblies Include="C:\Program Files\Epic Games\PathfinderWOTR\Wrath_Data\Managed\Assembly-CSharp.dll" />
+    </ItemGroup>
+    <PublicizeTask InputAssemblies="@(Assemblies)" OutputDir="$(SolutionDir)lib/" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>(robocopy "$(TargetDir) " "$(WrathPathDebug)\Mods\BubbleBuffs\ " /s /e )^&amp; IF %25ERRORLEVEL%25 LEQ 1 exit 0</PostBuildEvent>

--- a/BubbleBuffs/Config/en_GB.json
+++ b/BubbleBuffs/Config/en_GB.json
@@ -35,6 +35,7 @@
   "tooltip.skipped": "Buffs Skipped",
   "tooltip.failed": "Buffs Failed",
   "noslot": "no free spell-slot",
+  "noarcanist": "no available arcane reservoir points ",
 
   "warn.arcanepool": "  <i>Arcane Resevoir resource is <b>not</b> tracked</i>",
 

--- a/BubbleBuffs/Info.json
+++ b/BubbleBuffs/Info.json
@@ -10,5 +10,5 @@
     "Repository": "https://raw.githubusercontent.com/factubsio/BubbleBuffs/master/Repository.json",
     "Requirements": [],
     "LoadAfter": ["EnhancedInventory"],
-    "Version": "3.8.1"
+    "Version": "3.8.2"
 }

--- a/BubbleBuffs/Properties/Settings.Designer.cs
+++ b/BubbleBuffs/Properties/Settings.Designer.cs
@@ -25,13 +25,25 @@ namespace BubbleBuffs.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Program Files\\Epic Games\\PathfinderWOTR")]
         public string WratPath {
             get {
                 return ((string)(this["WratPath"]));
             }
             set {
                 this["WratPath"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("C:\\Program Files\\Epic Games\\PathfinderWOTR")]
+        public string WrathPathDebug {
+            get {
+                return ((string)(this["WrathPathDebug"]));
+            }
+            set {
+                this["WrathPathDebug"] = value;
             }
         }
     }

--- a/BubbleBuffs/Properties/Settings.settings
+++ b/BubbleBuffs/Properties/Settings.settings
@@ -3,7 +3,10 @@
   <Profiles />
   <Settings>
     <Setting Name="WratPath" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
+      <Value Profile="(Default)">C:\Program Files\Epic Games\PathfinderWOTR</Value>
+    </Setting>
+    <Setting Name="WrathPathDebug" Type="System.String" Scope="User">
+      <Value Profile="(Default)">C:\Program Files\Epic Games\PathfinderWOTR</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/BubbleBuffs/app.config
+++ b/BubbleBuffs/app.config
@@ -8,7 +8,10 @@
     <userSettings>
         <BubbleBuffs.Properties.Settings>
             <setting name="WratPath" serializeAs="String">
-                <value />
+                <value>C:\Program Files\Epic Games\PathfinderWOTR</value>
+            </setting>
+            <setting name="WrathPathDebug" serializeAs="String">
+                <value>C:\Program Files\Epic Games\PathfinderWOTR</value>
             </setting>
         </BubbleBuffs.Properties.Settings>
     </userSettings>

--- a/Repository.json
+++ b/Repository.json
@@ -2,7 +2,7 @@
     "Releases": [
         {
             "Id": "BubbleBuffs",
-            "Version": "3.8.1"
+            "Version": "3.8.2"
         }
     ]
 }


### PR DESCRIPTION
One issue with the BubbleBuffs mods is that it doesn't handle Arcanist points well when using a Brownfur Transmuter.

If you run out of points, Bubble will incorrectly apply the buffs without the special Brownfur options.

This is generally not what you want to do. You are using a Brownfur Transmuter for a reason!

This patch fixes the issue by stopping buff application when you run out of arcanist points.