### PR TITLE
Fix incorrectly applied buffs when out of Arcanist points

### DIFF
--- a/BubbleBuffs/BuffExecutor.cs
+++ b/BubbleBuffs/BuffExecutor.cs
@@ -46,6 +46,7 @@ namespace BubbleBuffs {
                 if (task.ShareTransmutation) {
                     var toggle = AbilityCache.CasterCache[task.Caster.UniqueId].ShareTransmutation;
                     if (toggle?.Data.IsAvailableForCast != true) {
+                        Main.Error("Was unable to cast share transmutation?");
                         return;
                     }
 
@@ -57,12 +58,15 @@ namespace BubbleBuffs {
 
                 if (task.PowerfulChange) {
                     var toggle = AbilityCache.CasterCache[task.Caster.UniqueId].PowerfulChange;
-                    if (toggle?.Data.IsAvailableForCast == true) {
-                        var toggleParams = toggle.Data.CalculateParams();
-                        var context = new AbilityExecutionContext(toggle.Data, toggleParams, new TargetWrapper(task.Caster));
-                        toggle.Data.Cast(context);
-                        toggle.Data.Spend();
+                    if (toggle?.Data.IsAvailableForCast != true) {
+                        Main.Error("Was unable to cast powerful change?");
+                        return;
                     }
+
+                    var toggleParams = toggle.Data.CalculateParams();
+                    var context = new AbilityExecutionContext(toggle.Data, toggleParams, new TargetWrapper(task.Caster));
+                    toggle.Data.Cast(context);
+                    toggle.Data.Spend();
                 }
 
                 {
@@ -138,6 +142,9 @@ namespace BubbleBuffs {
 
             List<CastTask> tasks = new();
 
+            Dictionary<UnitEntityData, int> remainingArcanistPool = new Dictionary<UnitEntityData, int>();
+            BlueprintScriptableObject arcanistPoolBlueprint = ResourcesLibrary.TryGetBlueprint<BlueprintScriptableObject>("cac948cbbe79b55459459dd6a8fe44ce");
+
             foreach (var buff in State.BuffList.Where(b => b.InGroup == buffGroup && b.Fulfilled > 0)) {
 
                 try {
@@ -164,6 +171,33 @@ namespace BubbleBuffs {
                             thisBuffBad++;
                             continue;
                         }
+
+                        int neededArcanistPool = 0;
+                        if (caster.PowerfulChange) {
+                            neededArcanistPool += 1;
+                        }
+                        if (caster.ShareTransmutation) {
+                            neededArcanistPool += 1;
+                        }
+
+                        if (neededArcanistPool != 0) {
+                            int availableArcanistPool;
+                            if (remainingArcanistPool.ContainsKey(caster.who)) {
+                                availableArcanistPool = remainingArcanistPool[caster.who];
+                            } else {
+                                availableArcanistPool = caster.who.Resources.GetResourceAmount(arcanistPoolBlueprint);
+                            }
+                            if (availableArcanistPool < neededArcanistPool) {
+                                if (badResult == null)
+                                    badResult = tooltip.AddBad(buff);
+                                badResult.messages.Add($"  [{caster.who.CharacterName}] => [{Bubble.GroupById[target].CharacterName}], {"noarcanist".i8()}");
+                                thisBuffBad++;
+                                continue;
+                            } else {
+                                remainingArcanistPool[caster.who] = availableArcanistPool - neededArcanistPool;
+                            }
+                        }
+
                         var touching = caster.spell.Blueprint.GetComponent<AbilityEffectStickyTouch>();
                         if (touching) {
                             spellToCast = new AbilityData(caster.spell, touching.TouchDeliveryAbility);

--- a/BubbleBuffs/BufferState.cs
+++ b/BubbleBuffs/BufferState.cs
@@ -55,8 +55,17 @@ namespace BubbleBuffs {
                             Main.Verbose($"      Adding cantrip: {spell.Name}", "state");
                             AddBuff(dude, book, spell, null, credits, false, int.MaxValue, characterIndex);
                         }
-
-                        if (book.Blueprint.Spontaneous) {
+                        
+                        if (book.Blueprint.IsArcanist) {
+                            for (int level = 1; level <= book.LastSpellbookLevel; level++) {
+                                Main.Verbose($"    Looking at arcanist level {level}", "state");
+                                ReactiveProperty<int> credits = new ReactiveProperty<int>(book.GetSpellsPerDay(level));
+                                foreach (var slot in book.GetMemorizedSpells(level)) {
+                                    Main.Verbose($"      Adding arcanist buff: {slot.Spell.Name}", "state");
+                                    AddBuff(dude, book, slot.Spell, null, credits, false, int.MaxValue, characterIndex);
+                                }
+                            }
+                        } else if (book.Blueprint.Spontaneous) {
                             for (int level = 1; level <= book.LastSpellbookLevel; level++) {
                                 Main.Verbose($"    Looking at spont level {level}", "state");
                                 ReactiveProperty<int> credits = new ReactiveProperty<int>(book.GetSpellsPerDay(level));

--- a/BubbleBuffs/Config/en_GB.json
+++ b/BubbleBuffs/Config/en_GB.json
@@ -35,6 +35,7 @@
   "tooltip.skipped": "Buffs Skipped",
   "tooltip.failed": "Buffs Failed",
   "noslot": "no free spell-slot",
+  "noarcanist": "no available arcane reservoir points ",
 
   "warn.arcanepool": "  <i>Arcane Resevoir resource is <b>not</b> tracked</i>",
 

--- a/BubbleBuffs/Info.json
+++ b/BubbleBuffs/Info.json
@@ -10,5 +10,5 @@
     "Repository": "https://raw.githubusercontent.com/factubsio/BubbleBuffs/master/Repository.json",
     "Requirements": [],
     "LoadAfter": ["EnhancedInventory"],
-    "Version": "4.0.1"
+    "Version": "4.0.2"
 }

--- a/Repository.json
+++ b/Repository.json
@@ -2,7 +2,7 @@
     "Releases": [
         {
             "Id": "BubbleBuffs",
-            "Version": "4.0.1"
+            "Version": "4.0.2"
         }
     ]
 }


### PR DESCRIPTION
One issue with the BubbleBuffs mods is that it doesn't handle Arcanist points well when using a Brownfur Transmuter.

If you run out of points, Bubble will incorrectly apply the buffs without the special Brownfur options.

This is generally not what you want to do. You are using a Brownfur Transmuter for a reason!

This patch fixes the issue by stopping buff application when you run out of arcanist points.