### PR TITLE
Some fixing

### DIFF
--- a/BubbleBuffs/Extensions/ExtentionMethods.cs
+++ b/BubbleBuffs/Extensions/ExtentionMethods.cs
@@ -72,7 +72,7 @@ namespace BubbleBuffs.Extensions {
         }
 
         public static bool IsLong(this ContextActionApplyBuff action) {
-            return action.Permanent || (action.UseDurationSeconds && action.DurationSeconds >= 60) || action.DurationValue.Rate != DurationRate.Rounds;
+            return action.Permanent || (action.UseDurationSeconds ? action.DurationSeconds >= 60 : action.DurationValue.Rate != DurationRate.Rounds);
         }
         public static bool IsLong(this ContextActionEnchantWornItem action) {
             return action.Permanent || action.DurationValue.Rate != DurationRate.Rounds;

--- a/BubbleBuffs/Main.cs
+++ b/BubbleBuffs/Main.cs
@@ -202,12 +202,12 @@ namespace BubbleBuffs {
         }
         public static void Error(Exception e) {
             Log(e.ToString());
-            PFLog.Mods.Error(e.Message);
+            PFLog.Mods.Exception(e);
         }
         public static void Error(Exception e, string message) {
             Log(message);
             Log(e.ToString());
-            PFLog.Mods.Error(message);
+            PFLog.Mods.Exception(e, message);
         }
         public static void Error(string message) {
             Log(message);


### PR DESCRIPTION
There was a mistake in the IsLong extension method logic and it would crash ability preparing with an NPE when one of Dark Codex abilities was present. Fumi has already fixed on his side, but here's a PR just in case