### PR TITLE
Fixed opposition school issue (#34)

### DIFF
--- a/BubbleBuffs/BubbleBuff.cs
+++ b/BubbleBuffs/BubbleBuff.cs
@@ -225,21 +225,24 @@ namespace BubbleBuffs {
             if (spell.ConvertedFrom != null) {
                 return CreditsNeeded(spell.ConvertedFrom);
             }
+            return 1;
 
-            if (spell.Spellbook == null)
-                return 1;
-
-            if (spell.Spellbook.Blueprint.Spontaneous) {
-                return 1;
-            }
-            else {
-                if (spell.SpellSlot?.LinkedSlots != null && (spell.SpellSlot?.IsOpposition ?? false)) {
-                    return spell.SpellSlot.LinkedSlots.Count();
-                }
-                else {
-                    return 1;
-                }
-            }
+            //This doesn't seem to be necessary. We return 1 in most cases, and the only time we don't - it breaks cost calculation for opposig school spells, preventing use of those spells alltogether.
+            //Simply treating them as any other spell seems to work fine and not cause issues - the game seems to handle everything by itself just fine.
+            //if (spell.Spellbook == null)
+            //    return 1;
+            //
+            //if (spell.Spellbook.Blueprint.Spontaneous) {
+            //    return 1;
+            //}
+            //else {
+            //    if (spell.SpellSlot?.LinkedSlots != null && (spell.SpellSlot?.IsOpposition ?? false)) {
+            //        return spell.SpellSlot.LinkedSlots.Count();
+            //    }
+            //    else {
+            //        return 1;
+            //    }
+            //}
         }
 
         public void Validate() {

--- a/BubbleBuffs/BubbleBuffs.csproj
+++ b/BubbleBuffs/BubbleBuffs.csproj
@@ -5,7 +5,7 @@
 		<TargetFramework>net481</TargetFramework>
 		<AssemblyName>BubbleBuffs</AssemblyName>
 		<Description>BubbleBuffs</Description>
-		<Version>5.2.3</Version>
+		<Version>5.2.4</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<LangVersion>latest</LangVersion>
 		<RootNamespace>BubbleBuffs</RootNamespace>

--- a/BubbleBuffs/Info.json
+++ b/BubbleBuffs/Info.json
@@ -3,12 +3,12 @@
     "Author": "bubbles",
     "DisplayName": "Bubble Buffs",
     "EntryMethod": "BubbleBuffs.Main.Load",
-    "GameVersion": "1.4.0",
+    "GameVersion": "2.7.0",
     "HomePage": "https://www.nexusmods.com/pathfinderwrathoftherighteous/mods/195",
     "Id": "BubbleBuffs",
     "ManagerVersion": "0.23.0",
     "Repository": "https://raw.githubusercontent.com/factubsio/BubbleBuffs/master/Repository.json",
     "Requirements": [],
     "LoadAfter": ["EnhancedInventory"],
-    "Version": "5.2.2"
+    "Version": "5.2.4"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 5.2.4
+* Fixed Repository.json, Info.json versions to be in line with mod version
+* Bumped game version in Info.json to current
+* (Bug Fix) Removed LinkedSlot check that was causing Opposing School spells on Wizards to be never castable by BubbleBuff due to them counting as double credit when calculating the "cost" of buffing, but not counting the double slots they occupy when slotting in calculation of available credit for buffing.
+
 ## Version 5.1.4
 * Fixes and stuff
 

--- a/Repository.json
+++ b/Repository.json
@@ -2,7 +2,7 @@
     "Releases": [
         {
             "Id": "BubbleBuffs",
-            "Version": "5.2.2"
+            "Version": "5.2.4"
         }
     ]
 }


### PR DESCRIPTION
Fixes the following issue:
[Wizard opposition school spells don't track spell slots correctly #34](https://github.com/factubsio/BubbleBuffs/issues/34)

Bumps game version to current.
Bumps mod version to 5.2.4 (some jsons had an even older version).